### PR TITLE
Fix duplicate output with Pest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,11 +54,17 @@
         "test:lint": "pint --test",
         "test:types": "phpstan analyse --ansi",
         "test:unit": "phpunit",
+        "test:e2e": [
+            "vendor/bin/phpunit --colors=always --configuration=tests/EndToEnd/PHPUnit12/phpunit.xml",
+            "vendor/bin/phpunit --configuration=tests/EndToEnd/ParaTest/phpunit.xml",
+            "vendor/bin/phpunit --configuration=tests/EndToEnd/Pest4/phpunit.xml"
+        ],
         "test": [
             "@test:refacto",
             "@test:lint",
             "@test:types",
-            "@test:unit"
+            "@test:unit",
+            "@test:e2e"
         ]
     }
 }

--- a/src/FlakyFixExtension.php
+++ b/src/FlakyFixExtension.php
@@ -26,9 +26,13 @@ final class FlakyFixExtension implements Extension
         /**
          * Do not respect the `no-output` configuration for this extension.
          * This is necessary to work with `php artisan test`, Pest, and Paratest.
+         * However, we have to respect the `FLAKY_FIX_NO_OUTPUT` environment variable
+         * to prevent duplicate output when running tests from those PHPUnit wrappers.
          */
-        echo PHP_EOL
-            . sprintf('Flaky Test Seed: %s. To reproduce, run `FLAKY_SEED=%s php artisan test --filter ...`', self::$flakySeed, self::$flakySeed)
-            . PHP_EOL . PHP_EOL;
+        if (! isset($_SERVER['FLAKY_FIX_NO_OUTPUT']) || $_SERVER['FLAKY_FIX_NO_OUTPUT'] !== '1') {
+            echo PHP_EOL
+                . sprintf('Flaky Test Seed: %s. To reproduce, run `FLAKY_SEED=%s php artisan test --filter ...`', self::$flakySeed, self::$flakySeed)
+                . PHP_EOL . PHP_EOL;
+        }
     }
 }

--- a/src/Pest/Plugin.php
+++ b/src/Pest/Plugin.php
@@ -38,5 +38,11 @@ final class Plugin implements Bootable
             '  <fg=white;options=bold;bg=blue> INFO </> ' . $message,
             '',
         ]);
+
+        /**
+         * Set the environment variable to indicate that the Flaky Fix output should be disabled.
+         * This is used to prevent duplicate output when running tests with Pest.
+         */
+        $_SERVER['FLAKY_FIX_NO_OUTPUT'] = '1';
     }
 }

--- a/tests/EndToEnd/PHPUnit10/Usage/Default/test.phpt
+++ b/tests/EndToEnd/PHPUnit10/Usage/Default/test.phpt
@@ -17,4 +17,4 @@ $application->run($_SERVER['argv']);
 --EXPECTF--
 Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/PHPUnit10/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/PHPUnit10/Usage/WithEnv/test.phpt
@@ -19,4 +19,4 @@ putenv('FLAKY_SEED');
 --EXPECTF--
 Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/PHPUnit11/Usage/Default/test.phpt
+++ b/tests/EndToEnd/PHPUnit11/Usage/Default/test.phpt
@@ -17,4 +17,4 @@ $application->run($_SERVER['argv']);
 --EXPECTF--
 Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/PHPUnit11/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/PHPUnit11/Usage/WithEnv/test.phpt
@@ -19,4 +19,4 @@ putenv('FLAKY_SEED');
 --EXPECTF--
 Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/PHPUnit12/Usage/Default/test.phpt
+++ b/tests/EndToEnd/PHPUnit12/Usage/Default/test.phpt
@@ -17,4 +17,4 @@ $application->run($_SERVER['argv']);
 --EXPECTF--
 Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/PHPUnit12/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/PHPUnit12/Usage/WithEnv/test.phpt
@@ -19,4 +19,4 @@ putenv('FLAKY_SEED');
 --EXPECTF--
 Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`
 
-%a
+PHPUnit %a

--- a/tests/EndToEnd/ParaTest/Usage/Default/test.phpt
+++ b/tests/EndToEnd/ParaTest/Usage/Default/test.phpt
@@ -11,4 +11,4 @@ ParaTest %a
 
 Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`
 
-%a
+Processes: %a

--- a/tests/EndToEnd/ParaTest/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/ParaTest/Usage/WithEnv/test.phpt
@@ -11,4 +11,4 @@ ParaTest %a
 
 Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`
 
-%a
+Processes: %a

--- a/tests/EndToEnd/Pest2/Usage/Default/test-parallel.phpt
+++ b/tests/EndToEnd/Pest2/Usage/Default/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --configuration=tests/EndToEnd/Pest2/Usage/Default/php
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest2/Usage/Default/test-parallel.phpt
+++ b/tests/EndToEnd/Pest2/Usage/Default/test-parallel.phpt
@@ -10,4 +10,4 @@ passthru('vendor/bin/pest --configuration=tests/EndToEnd/Pest2/Usage/Default/php
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
 
-%s.%a
+%s PASS %a

--- a/tests/EndToEnd/Pest2/Usage/Default/test.phpt
+++ b/tests/EndToEnd/Pest2/Usage/Default/test.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --configuration=tests/EndToEnd/Pest2/Usage/Default/php
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s PASS %a

--- a/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/P
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
@@ -10,4 +10,4 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/P
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
 
-%s.%a
+%s PASS %a

--- a/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest2/Usage/WithEnv/test-parallel.phpt
@@ -5,7 +5,7 @@ With default configuration of extension
 
 declare(strict_types=1);
 
-passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/Pest2/Usage/Default/phpunit.xml');
+passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/Pest2/Usage/WithEnv/phpunit.xml');
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 

--- a/tests/EndToEnd/Pest2/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/Pest2/Usage/WithEnv/test.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/P
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s PASS %a

--- a/tests/EndToEnd/Pest3/Usage/Default/test-parallel.phpt
+++ b/tests/EndToEnd/Pest3/Usage/Default/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --parallel --configuration=tests/EndToEnd/Pest3/Usage/
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest3/Usage/Default/test.phpt
+++ b/tests/EndToEnd/Pest3/Usage/Default/test.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --configuration=tests/EndToEnd/Pest3/Usage/Default/php
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s PASS %a

--- a/tests/EndToEnd/Pest3/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest3/Usage/WithEnv/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --parallel --configuration=tests
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest3/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest3/Usage/WithEnv/test-parallel.phpt
@@ -5,7 +5,7 @@ With default configuration of extension
 
 declare(strict_types=1);
 
-passthru('FLAKY_SEED=1234567890 vendor/bin/pest --parallel --configuration=tests/EndToEnd/Pest3/Usage/Default/phpunit.xml');
+passthru('FLAKY_SEED=1234567890 vendor/bin/pest --parallel --configuration=tests/EndToEnd/Pest3/Usage/WithEnv/phpunit.xml');
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 

--- a/tests/EndToEnd/Pest3/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/Pest3/Usage/WithEnv/test.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/P
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s PASS %a

--- a/tests/EndToEnd/Pest4/Usage/Default/test-parallel.phpt
+++ b/tests/EndToEnd/Pest4/Usage/Default/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --parallel --configuration=tests/EndToEnd/Pest4/Usage/
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest4/Usage/Default/test.phpt
+++ b/tests/EndToEnd/Pest4/Usage/Default/test.phpt
@@ -9,4 +9,5 @@ passthru('vendor/bin/pest --configuration=tests/EndToEnd/Pest4/Usage/Default/php
 --EXPECTF--
 %s Flaky Test Seed: %d. To reproduce, run `FLAKY_SEED=%d php artisan test --filter ...`.
 
-%a
+
+%s PASS %a

--- a/tests/EndToEnd/Pest4/Usage/WithEnv/test-parallel.phpt
+++ b/tests/EndToEnd/Pest4/Usage/WithEnv/test-parallel.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --parallel --configuration=tests
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s.%a

--- a/tests/EndToEnd/Pest4/Usage/WithEnv/test.phpt
+++ b/tests/EndToEnd/Pest4/Usage/WithEnv/test.phpt
@@ -9,4 +9,5 @@ passthru('FLAKY_SEED=1234567890 vendor/bin/pest --configuration=tests/EndToEnd/P
 --EXPECTF--
 %s Flaky Test Seed: 1234567890. To reproduce, run `FLAKY_SEED=1234567890 php artisan test --filter ...`.
 
-%a
+
+%s PASS %a


### PR DESCRIPTION
Running the test suite with Pest (single-threaded only) would output the Flaky Fix message twice (with the same seed).
Once by the Pest Plugin
Once by the PHPUnit extension